### PR TITLE
Correctly encode ampersands (`&`) in the URL to `carbonads.com`.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
       <embed width="1" height="1" src="ZeroClipboard.swf" play="true" name="flashtest" type="application/x-shockwave-flash">
     </div>
     <div id="ad">
-      <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=emojicheatsheetcom" id="_carbonads_js"></script>
+      <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&amp;serve=C6AILKT&amp;placement=emojicheatsheetcom" id="_carbonads_js"></script>
     </div>
 
     <p id="description">


### PR DESCRIPTION
Ampersands should be encoded as `&amp;` in the HTML source. This still
works without the proper encoding because browsers are lenient, but it's
technically incorrect.